### PR TITLE
fix: canvasの描画領域の高さを算出

### DIFF
--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -1,10 +1,37 @@
 import { Canvas } from '@react-three/fiber';
 import Sphere from './Sphere';
 import { OrbitControls } from '@react-three/drei';
+import { useEffect, useRef } from 'react';
 
 const Scene = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // NOTE: footer・headerの高さを含めないCanvasの描画領域の高さを取得する
+  useEffect(() => {
+    const updateHeight = () => {
+      if (!containerRef.current) return;
+      const header = document.querySelector('header');
+      const footer = document.querySelector('footer');
+      if (!header || !footer) return;
+
+      const headerHeight = header.getBoundingClientRect().height;
+      const footerHeight = footer.getBoundingClientRect().height;
+      const windowHeight = window.innerHeight;
+      const availableHeight = windowHeight - headerHeight - footerHeight;
+
+      containerRef.current.style.height = `${availableHeight}px`;
+    };
+
+    updateHeight();
+    window.addEventListener('resize', updateHeight);
+
+    return () => {
+      window.removeEventListener('resize', updateHeight);
+    };
+  }, []);
+
   return (
-    <div className="absolute inset-0 w-full h-full">
+    <div ref={containerRef} className="w-full">
       <Canvas
         camera={{
           position: [0, 0, 5],


### PR DESCRIPTION
### 概要
スマホだとfooterの高さもcanvasの描画領域に含められてしまうため、viewportの高さからfooter/headerの高さを引いた値をcanvasの領域の高さに設定。